### PR TITLE
Update django.yml to migrate database

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -25,6 +25,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Migrate Database
+      run: |
+        python manage.py makemigrations
+        python manage.py migrate
     - name: Run Tests
       run: |
         python manage.py test


### PR DESCRIPTION
Allow for migrations folder to be part of .gitignore by moving migrate function to the workflow.