### PR TITLE
E1.12 Student Balance Adjustments

### DIFF
--- a/lessons/forms.py
+++ b/lessons/forms.py
@@ -9,16 +9,26 @@ class RequestForm(forms.ModelForm):
     class Meta:
         model = Request
         exclude = ['student','status']
+        localized_fields = ('date','time')
+        labels = {
+            'date': ('Date (YYYY-MM-DD)'),
+            'time': ('Time (HH:MM)'),
+            'amount': ('Number of lessons:'),
+            'interval': ('Number of weeks between lessons'),
+        }
+        
 
     """Override clean method to check date and time"""
     def clean(self):
         super().clean()
         date = self.cleaned_data.get('date')
         if (date == None):
+            self.add_error('date','Please enter the date as YYYY-MM-DD.')
             return
             
         time = self.cleaned_data.get('time')
         if (time == None):
+            self.add_error('time','Please enter the time as HH:MM.')
             return
 
         if(date <= timezone.now().date()):

--- a/lessons/helpers.py
+++ b/lessons/helpers.py
@@ -26,24 +26,6 @@ def get_all_bookings():
 def get_all_transfers():
     return Transfer.objects.all()
 
-def adjust_student_balance(student, transfer_amount):
-    user_bookings = get_user_bookings(student)
-    unpaid_invoices = Invoice.objects.filter(is_paid=False).filter(booking__in=user_bookings)
-    remaining_transfer_amount = transfer_amount
-    paid_invoice_total = 0
-    for invoice in unpaid_invoices:
-        if (transfer_amount >= invoice.total_price) or (transfer_amount + student.balance >= invoice.total_price):
-            invoice.is_paid = True
-            invoice.date_paid = timezone.now()
-            invoice.save()
-            remaining_transfer_amount -= invoice.total_price
-            paid_invoice_total += invoice.total_price
-    
-    if(transfer_amount != 0):
-        student.increase_balance(transfer_amount)
-    else:
-        student.decrease_balance(paid_invoice_total)
-
 def check_for_refund(booking):
     invoice = Invoice.objects.get(booking=booking)
     if invoice.is_paid:

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.core.validators import MinValueValidator, MaxValueValidator, StepValueValidator, DecimalValidator
 from decimal import Decimal
+from django.utils import timezone
 class User(AbstractUser):
     """User model used for authentication and lessons authoring."""
 
@@ -169,26 +170,14 @@ class Booking(models.Model):
     
     def generate_invoice(self):
         Invoice.objects.create(booking=self, total_price=self.get_price,date_paid=None)
-        self.student.decrease_balance(self.get_price)
 
     def edit_invoice(self):
         invoice = Invoice.objects.get(booking=self)
-        new_price = self.get_price
+        invoice.total_price = self.get_price
+        invoice.is_paid = False
+        invoice.date_paid = None
+        invoice.save()
 
-        if(invoice.total_price < new_price):
-            # The new price is more expensive than the original
-            self.student.increase_balance(invoice.total_price)
-            self.student.decrease_balance(new_price)
-            invoice.total_price=new_price
-            invoice.is_paid=False
-            invoice.date_paid= None
-            invoice.save()
-        elif (invoice.total_price > new_price):
-            # The new price is cheaper than the original payment
-            self.student.increase_balance(invoice.total_price)
-            self.student.decrease_balance(new_price)
-            invoice.total_price=new_price
-            invoice.save()
 
     @property
     def get_price(self):

--- a/lessons/templates/partials/bootstrap_form.html
+++ b/lessons/templates/partials/bootstrap_form.html
@@ -14,7 +14,6 @@
       <label for = render_field>{{ field.label_tag}}</label>
     {% endif %}
     <div class="valid-feedback">
-      Looks good!
     </div>
     <div class="invalid-feedback">
       {{ field.errors }}

--- a/lessons/templates/partials/invoice_as_table.html
+++ b/lessons/templates/partials/invoice_as_table.html
@@ -19,9 +19,12 @@
                     <p>{{invoice.date_paid}}</p>
                 </div>
             {%else%}
-            <div class="alert alert-danger" role="alert">
-                Not Paid!
-            </div>
+                <div class="alert alert-danger" role="alert">
+                    Not Paid!
+                </div>
+                {% if user.is_student %}
+                    <a href="{%url 'pay_invoice' invoice.booking.id %}" type="button" class="btn btn-success">Pay Invoice</a>
+                {%endif%}
             {%endif%}
         </td>
     </tr>

--- a/lessons/templates/partials/menu.html
+++ b/lessons/templates/partials/menu.html
@@ -11,9 +11,11 @@
     <li class="nav-item">
       <a class="nav-link" href="{% url 'bookings'%}">Booked Lessons</a>
     </li>
-    <li class="nav-item">
-      <a class="nav-link" href="{% url 'transfers'%}">Transfers</a>
-    </li>
+    {% if user.is_admin %}
+      <li class="nav-item">
+        <a class="nav-link" href="{% url 'transfers'%}">Transfers</a>
+      </li>
+    {% endif %}
   </ul>
   <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
     <li class="nav-item dropdown">

--- a/lessons/tests/models/test_invoice_model.py
+++ b/lessons/tests/models/test_invoice_model.py
@@ -79,7 +79,6 @@ class InvoiceTest(TestCase):
         self.assertEqual(5*2*4,invoice.total_price)
 
     def test_invoice_update_correctly_when_more_than_total_is_transferred(self):
-        print("\nThis test\n")
         self.booking.generate_invoice()
         self.client.login(username=self.admin.username, password='Password123')
         self.form_input['amount'] = '50' 

--- a/lessons/tests/models/test_invoice_model.py
+++ b/lessons/tests/models/test_invoice_model.py
@@ -42,28 +42,36 @@ class InvoiceTest(TestCase):
     def test_invoice_update_correctly_when_total_is_transferred(self):
         self.booking.generate_invoice()
         self.client.login(username=self.admin.username, password='Password123')
-
-        self.assertEqual(self.user.balance, -40)
+        invoice = Invoice.objects.get(booking=self.booking)
+        self.assertEqual(5*2*4,invoice.total_price)
+        
+        self.assertEqual(self.user.balance, 0)
         self.client.post(reverse('transfers'), self.form_input, follow=True)
         self.user = User.objects.get(username='johndoe@example.org')
-        self.assertEqual(self.user.balance, 0)
+        self.assertEqual(self.user.balance, 40)
 
+        self.client.logout()
+        self.client.login(username=self.user.username, password='Password123')
+        self.client.get(reverse('pay_invoice', kwargs={'booking_id': self.booking.id }))
         invoice = Invoice.objects.get(booking=self.booking)
         self.assertEqual(invoice.booking, self.booking)
-        self.assertIsNotNone(invoice.date_paid)
         self.assertTrue(invoice.is_paid)
-        self.assertEqual(5*2*4,invoice.total_price)
+        self.assertIsNotNone(invoice.date_paid)
+        
 
     def test_invoice_update_correctly_when_less_than_total_is_transferred(self):
         self.booking.generate_invoice()
         self.client.login(username=self.admin.username, password='Password123')
         self.form_input['amount'] = '30'
 
-        self.assertEqual(self.user.balance, -40)
+        self.assertEqual(self.user.balance, 0)
         self.client.post(reverse('transfers'), self.form_input, follow=True)
         self.user = User.objects.get(username='johndoe@example.org')
-        self.assertEqual(self.user.balance, -10)
+        self.assertEqual(self.user.balance, 30)
 
+        self.client.logout()
+        self.client.login(username=self.user.username, password='Password123')
+        self.client.get(reverse('pay_invoice', kwargs={'booking_id': self.booking.id }))
         invoice = Invoice.objects.get(booking=self.booking)
         self.assertEqual(invoice.booking, self.booking)
         self.assertIsNone(invoice.date_paid)
@@ -71,17 +79,23 @@ class InvoiceTest(TestCase):
         self.assertEqual(5*2*4,invoice.total_price)
 
     def test_invoice_update_correctly_when_more_than_total_is_transferred(self):
+        print("\nThis test\n")
         self.booking.generate_invoice()
         self.client.login(username=self.admin.username, password='Password123')
         self.form_input['amount'] = '50' 
 
-        self.assertEqual(self.user.balance, -40)
+        self.assertEqual(self.user.balance, 0)
         self.client.post(reverse('transfers'), self.form_input, follow=True)
         self.user = User.objects.get(username='johndoe@example.org')
-        self.assertEqual(self.user.balance,10)
+        self.assertEqual(self.user.balance,50)
 
+        self.client.logout()
+        self.client.login(username=self.user.username, password='Password123')
+        self.client.get(reverse('pay_invoice', kwargs={'booking_id': self.booking.id }))
         invoice = Invoice.objects.get(booking=self.booking)
         self.assertEqual(invoice.booking, self.booking)
         self.assertIsNotNone(invoice.date_paid)
         self.assertTrue(invoice.is_paid)
         self.assertEqual(5*2*4,invoice.total_price)
+        self.user = User.objects.get(username='johndoe@example.org')
+        self.assertEqual(self.user.balance,10)

--- a/lessons/tests/views/test_pay_invoice_view.py
+++ b/lessons/tests/views/test_pay_invoice_view.py
@@ -1,0 +1,134 @@
+from django.test import TestCase
+from django.urls import reverse
+from lessons.models import Invoice, User, Booking
+from lessons.tests.helpers import reverse_with_next
+
+class PayInvoiceViewTestCase(TestCase):
+    """Test case of new request view"""
+
+    fixtures = [
+        'lessons/tests/fixtures/default_user.json',
+        'lessons/tests/fixtures/other_users.json',
+        'lessons/tests/fixtures/default_admin.json'
+    ]
+
+    def setUp(self):
+        
+        self.user = User.objects.get(username='johndoe@example.org')
+        self.admin = User.objects.get(username='petra.pickles@example.org')
+
+        self.booking = Booking(
+            student=self.user,
+            day="Monday",
+            time="14:30",
+            start_date="2022-11-16",
+            duration=30,
+            interval=1,
+            teacher="Mrs.Smith",
+            no_of_lessons=4,
+            topic="Violin",
+            cost=5
+        )
+        self.booking.save()
+        self.booking.generate_invoice()
+        self.invoice = Invoice.objects.get(booking = self.booking)
+        self.url = reverse('pay_invoice', kwargs={'booking_id': self.booking.pk})
+
+    def test_pay_invoice_url(self):
+        self.assertEqual(self.url,f'/pay_invoice/{self.booking.pk}')
+    
+    def test_get_pay_invoice(self):
+        self.client.login(username=self.user.username, password='Password123')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'view_invoice.html')
+        messages_list = list(response.context['messages'])
+        self.assertEqual(len(messages_list), 1)
+    
+    def test_get_pay_invoice_redirects_when_not_logged_in(self):
+        response = self.client.get(self.url, follow=True)
+        redirect_url = reverse_with_next('log_in', self.url)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+        self.assertTemplateUsed(response, 'log_in.html')
+
+    def test_get_pay_invoice_redirects_for_admins(self):
+        self.client.login(username=self.admin.username, password='Password123')
+        redirect_url = reverse('feed')
+        response = self.client.get(self.url, follow=True)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+        self.assertTemplateUsed(response, 'feed.html')
+        messages_list = list(response.context['messages'])
+        self.assertEqual(len(messages_list), 1)
+    
+    def test_get_pay_invoice_sets_invoice_correctly_with_full_amount(self):
+        self.user.balance = 40
+        self.user.save()
+        self.client.login(username=self.user.username, password='Password123')
+
+        response = self.client.get(self.url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'view_invoice.html')
+        messages_list = list(response.context['messages'])
+        self.assertEqual(len(messages_list), 1)
+        
+        self.invoice = Invoice.objects.get(id=self.booking.pk)
+        self.user = User.objects.get(username='johndoe@example.org')
+
+        self.assertEqual(self.user.balance, 0)
+        self.assertTrue(self.invoice.is_paid)
+        self.assertIsNotNone(self.invoice.date_paid)
+    
+    def test_get_pay_invoice_sets_invoice_correctly_with_under_amount(self):
+        self.user.balance = 30
+        self.user.save()
+
+        self.client.login(username=self.user.username, password='Password123')
+        response = self.client.get(self.url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'view_invoice.html')
+        messages_list = list(response.context['messages'])
+        self.assertEqual(len(messages_list), 1)
+        
+        self.invoice = Invoice.objects.get(id=self.booking.pk)
+        self.user = User.objects.get(username='johndoe@example.org')
+
+        self.assertEqual(self.user.balance, 30)
+        self.assertFalse(self.invoice.is_paid)
+        self.assertIsNone(self.invoice.date_paid)
+    
+    def test_get_pay_invoice_sets_invoice_correctly_with_over_amount(self):
+        self.user.balance = 50
+        self.user.save()
+
+        self.client.login(username=self.user.username, password='Password123')
+        response = self.client.get(self.url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'view_invoice.html')
+        messages_list = list(response.context['messages'])
+        self.assertEqual(len(messages_list), 1)
+        
+        self.invoice = Invoice.objects.get(id=self.booking.pk)
+        self.user = User.objects.get(username='johndoe@example.org')
+
+        self.assertEqual(self.user.balance, 10)
+        self.assertTrue(self.invoice.is_paid)
+        self.assertIsNotNone(self.invoice.date_paid)
+    
+    def test_post_pay_invoice_is_rejected(self):
+        self.client.login(username=self.user.username, password='Password123')
+        response = self.client.post(self.url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'view_invoice.html')
+    
+    def test_get_pay_invoice_redirects_if_invoice_not_found(self):
+        self.client.login(username=self.user.username, password='Password123')
+        self.url = reverse('pay_invoice', kwargs={'booking_id': Booking.objects.count() +1})
+        response = self.client.get(self.url, follow=True)
+        redirect_url = reverse('bookings')
+        response = self.client.get(self.url, follow=True)
+        self.assertRedirects(response, redirect_url,
+            status_code=302, target_status_code=200, fetch_redirect_response=True
+        )
+        self.assertTemplateUsed(response, 'bookings.html')
+        messages_list = list(response.context['messages'])
+        self.assertEqual(len(messages_list), 2)

--- a/lessons/views.py
+++ b/lessons/views.py
@@ -302,15 +302,15 @@ def transfers(request):
 @login_required
 @student_required
 def pay_invoice(request, booking_id):
+    try:
+        booking = Booking.objects.get(id=booking_id)
+        student = booking.student
+        invoice = Invoice.objects.get(booking=booking)
+    except:
+        messages.add_message(request, messages.ERROR, "Sorry, could not locate the invoice!")
+        return redirect('bookings')
+        
     if request.method == 'GET':
-        try:
-            booking = Booking.objects.get(id=booking_id)
-            student = booking.student
-            invoice = Invoice.objects.get(booking=booking)
-        except:
-            messages.add_message(request, messages.ERROR, "Sorry, could not locate the invoice!")
-            return render(request, 'view_invoice.html', {'invoice' : invoice})
-
         if(student.balance >= invoice.total_price):
             student.decrease_balance(invoice.total_price)
             invoice.is_paid = True

--- a/lessons/views.py
+++ b/lessons/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, redirect
 from django.http import HttpResponseForbidden
-from .models import Request, Booking, Invoice, Transfer
-from .helpers import get_user_requests, get_all_requests, get_user_bookings, get_all_bookings, get_all_transfers, adjust_student_balance, check_for_refund
+from .models import Request, Booking, Invoice, Transfer, User
+from .helpers import get_user_requests, get_all_requests, get_user_bookings, get_all_bookings, get_all_transfers, check_for_refund
 from django.contrib.auth.decorators import login_required
 from .forms import SignUpForm, LogInForm, RequestForm, BookingForm, TransferForm
 from django.contrib.auth import login, logout
@@ -200,7 +200,6 @@ def new_booking(request, id):
             )
             booking_request = Booking.objects.all().latest('id')
             booking_request.generate_invoice()
-            adjust_student_balance(pending_request.student,0)
             Request.objects.filter(id=id).delete()
             messages.add_message(request, messages.SUCCESS, "Booking successfully created!")
             return redirect('feed')
@@ -233,7 +232,8 @@ def update_booking(request, id):
         if (form.is_valid()):
             messages.add_message(request, messages.SUCCESS, "Booking successfully updated!")
             form.save()
-            booking_request.edit_invoice()
+            check_for_refund(Booking.objects.get(pk=id))
+            Booking.objects.get(pk=id).edit_invoice()
             return redirect('bookings')
         else:
             return render(request, 'update_booking.html', {'form': form, 'request' : booking_request})
@@ -289,8 +289,8 @@ def transfers(request):
                 amount = Decimal(form.cleaned_data.get('amount')),
                 date = timezone.now()
             )
-            adjust_student_balance(form.cleaned_data.get('student'),form.cleaned_data.get('amount'))
             messages.add_message(request, messages.SUCCESS, "Transfer Added!")
+            form.cleaned_data.get('student').increase_balance(Decimal(form.cleaned_data.get('amount')))
             form = TransferForm()
             return render(request, 'transfers.html', {'transfers' : transfers, 'form' : form})
         else:
@@ -299,3 +299,28 @@ def transfers(request):
         form = TransferForm()
         return render(request, 'transfers.html', {'transfers' : transfers, 'form' : form})
 
+@login_required
+@student_required
+def pay_invoice(request, booking_id):
+    if request.method == 'GET':
+        try:
+            booking = Booking.objects.get(id=booking_id)
+            student = booking.student
+            invoice = Invoice.objects.get(booking=booking)
+        except:
+            messages.add_message(request, messages.ERROR, "Sorry, could not locate the invoice!")
+            return render(request, 'view_invoice.html', {'invoice' : invoice})
+
+        if(student.balance >= invoice.total_price):
+            student.decrease_balance(invoice.total_price)
+            invoice.is_paid = True
+            invoice.date_paid = timezone.now()
+            invoice.save()
+            messages.add_message(request, messages.SUCCESS, "Invoice was paid!")
+            invoice = Invoice.objects.get(booking=booking)
+            return render(request, 'view_invoice.html', {'invoice' : invoice})
+        else:
+            messages.add_message(request, messages.WARNING, "Sorry, your balance is too low to pay this invoice")
+            return render(request, 'view_invoice.html', {'invoice' : invoice})
+    else:
+        return render(request, 'view_invoice.html', {'invoice' : invoice})

--- a/msms/urls.py
+++ b/msms/urls.py
@@ -34,4 +34,5 @@ urlpatterns = [
     path('bookings/', views.bookings, name='bookings'),
     path('view_invoice/<int:booking_id>', views.view_invoice, name='view_invoice'),
     path('transfers/', views.transfers, name='transfers'),
+    path('pay_invoice/<int:booking_id>', views.pay_invoice, name='pay_invoice'),
 ]


### PR DESCRIPTION
### Major Changes

- Removed the adjust student balance helper and all references to its use
- Edit invoice function of bookings has no other logic other than update fields
- Added a pay invoice button to invoices for students (This is no longer a backend operation)
- Added a pay_invoice view to handle the logic behind invoice amounts and student balance

**An invoice is no longer charged to the account** instead it is up to the user to pay the invoices with the balance they have from transfers. If this can be done, the invoice is deducted from their balance.

### Minor Changes
- Minor request form changes for better interaction
- Changes to the handling of refunds (When a booking is cancelled) to handle the new approach to balance
- Changes to handling of booking edits when changing balance and invoice amount - the full original amount is refunded and the new invoice is marked not paid.
### Screenshots
<img width="1461" alt="Screenshot 2022-12-06 at 14 26 03" src="https://user-images.githubusercontent.com/93386110/205938005-f7e89ba7-c6e8-4d40-9012-965e86936b6e.png">
<img width="1470" alt="Screenshot 2022-12-06 at 14 26 19" src="https://user-images.githubusercontent.com/93386110/205938083-0efa113b-8d42-45c8-8d64-ea47b8890d9a.png">

<img width="1469" alt="Screenshot 2022-12-06 at 14 26 53" src="https://user-images.githubusercontent.com/93386110/205938218-79a251f0-ea00-4f86-9f70-dc170c74c670.png">
